### PR TITLE
Adds support for "extend_to_subword"

### DIFF
--- a/expand_to_subword.py
+++ b/expand_to_subword.py
@@ -1,0 +1,38 @@
+import re
+
+try:
+    import expand_to_regex_set
+except:
+    from . import expand_to_regex_set
+
+
+def expand_to_subword(string, start, end):
+    # if it is an upper case word search for upper case chars
+    # else search for lower case chars
+    if(_is_inside_upper(string, start, end)):
+        regex = re.compile(r"[A-Z]")
+    else:
+        regex = re.compile(r"[a-z]")
+
+    result = expand_to_regex_set._expand_to_regex_rule(
+        string, start, end, regex, "subword")
+    if result is None:
+        return None
+    # check if it is prefixed by an upper char
+    # expand from camelC|ase| to camel|Case|
+    upper = re.compile(r"[A-Z]")
+    if upper.match(string[result["start"]-1:result["start"]]):
+        result["start"] -= 1
+    return result
+
+
+def _is_inside_upper(string, start, end):
+    if start != end:
+        return string[start:end].isupper()
+    start = max(0, start-2)
+    end = min(end + 2, len(string))
+    sub_str = string[start:end]
+    contains_upper = re.search(r"[A-Z]{2}", sub_str)
+    sub_str = sub_str[1:3]
+    contains_lower = re.search(r"[a-z]", sub_str)
+    return bool(contains_upper) and not bool(contains_lower)

--- a/html.py
+++ b/html.py
@@ -1,14 +1,23 @@
 try:
   import expand_to_word
+  import expand_to_subword
   import expand_to_quotes
   import expand_to_xml_node
 except:
   from . import expand_to_word
+  from . import expand_to_subword
   from . import expand_to_quotes
   from . import expand_to_xml_node
 
 def expand(string, start, end):
   expand_stack = []
+
+  expand_stack.append("subword")
+
+  result = expand_to_subword.expand_to_subword(string, start, end)
+  if result:
+    result["expand_stack"] = expand_stack
+    return result
 
   expand_stack.append("word")
 

--- a/javascript.py
+++ b/javascript.py
@@ -1,5 +1,6 @@
 try:
   import expand_to_word
+  import expand_to_subword
   import expand_to_word_with_dots
   import expand_to_symbols
   import expand_to_quotes
@@ -7,6 +8,7 @@ try:
   import utils
 except:
   from . import expand_to_word
+  from . import expand_to_subword
   from . import expand_to_word_with_dots
   from . import expand_to_symbols
   from . import expand_to_quotes
@@ -56,6 +58,13 @@ def expand(string, start, end):
 
 def expand_agains_line(string, start, end):
   expand_stack = []
+
+  expand_stack.append("subword")
+
+  result = expand_to_subword.expand_to_subword(string, start, end)
+  if result:
+    result["expand_stack"] = expand_stack
+    return result
 
   expand_stack.append("word")
 

--- a/test/integration_javascript.py
+++ b/test/integration_javascript.py
@@ -15,37 +15,45 @@ class JavascriptIntegrationTest(unittest.TestCase):
     with open ("test/snippets/integration_04.txt", "r") as myfile:
       self.string4 = myfile.read()
 
-  def test_word (self):
+  def test_subword (self):
     result = expand(self.string1, 7, 7);
     self.assertEqual(result["start"], 6)
     self.assertEqual(result["end"], 9)
     self.assertEqual(result["string"], "bar")
-    self.assertEqual(result["type"], "word")
-    self.assertEqual(result["expand_stack"], ["word"])
+    self.assertEqual(result["type"], "subword")
+    self.assertEqual(result["expand_stack"], ["subword"])
 
-  def test_quotes_inner (self):
+  def test_word (self):
     result = expand(self.string1, 6, 9);
     self.assertEqual(result["start"], 2)
     self.assertEqual(result["end"], 9)
-    self.assertEqual(result["string"], "foo bar")
+    self.assertEqual(result["string"], "foo_bar")
+    self.assertEqual(result["type"], "word")
+    self.assertEqual(result["expand_stack"], ["subword", "word"])
+
+  def test_quotes_inner (self):
+    result = expand(self.string1, 2, 9);
+    self.assertEqual(result["start"], 2)
+    self.assertEqual(result["end"], 17)
+    self.assertEqual(result["string"], "foo_bar foo bar")
     self.assertEqual(result["type"], "quotes")
-    self.assertEqual(result["expand_stack"], ["word", "quotes"])
+    self.assertEqual(result["expand_stack"], ["subword", "word", "quotes"])
 
   def test_quotes_outer (self):
-    result = expand(self.string1, 2, 9);
+    result = expand(self.string1, 2, 17);
     self.assertEqual(result["start"], 1)
-    self.assertEqual(result["end"], 10)
-    self.assertEqual(result["string"], "\"foo bar\"")
+    self.assertEqual(result["end"], 18)
+    self.assertEqual(result["string"], "\"foo_bar foo bar\"")
     self.assertEqual(result["type"], "quotes")
-    self.assertEqual(result["expand_stack"], ["word", "quotes"])
+    self.assertEqual(result["expand_stack"], ["subword", "word", "quotes"])
 
   def test_symbol_inner (self):
     result = expand(self.string1, 1, 10);
     self.assertEqual(result["start"], 1)
-    self.assertEqual(result["end"], 16)
-    self.assertEqual(result["string"], "\"foo bar\" + \"x\"")
+    self.assertEqual(result["end"], 24)
+    self.assertEqual(result["string"], "\"foo_bar foo bar\" + \"x\"")
     self.assertEqual(result["type"], "semantic_unit")
-    self.assertEqual(result["expand_stack"], ["word", "quotes", "semantic_unit"])
+    self.assertEqual(result["expand_stack"], ["subword", "word", "quotes", "semantic_unit"])
 
   def test_dont_expand_to_dots (self):
     result = expand(self.string2, 2, 5);
@@ -53,7 +61,7 @@ class JavascriptIntegrationTest(unittest.TestCase):
     self.assertEqual(result["end"], 10)
     self.assertEqual(result["string"], " foo.bar ")
     self.assertEqual(result["type"], "quotes")
-    self.assertEqual(result["expand_stack"], ["word", "quotes"])
+    self.assertEqual(result["expand_stack"], ["subword", "word", "quotes"])
 
   # def test_expand_to_line (self):
   #   result = expand(self.string3, 30, 35);
@@ -61,7 +69,7 @@ class JavascriptIntegrationTest(unittest.TestCase):
   #   self.assertEqual(result["end"], 37)
   #   self.assertEqual(result["string"], "foo: true")
   #   self.assertEqual(result["type"], "line")
-  #   self.assertEqual(result["expand_stack"], ["word", "quotes", "semantic_unit", "symbols", "line"])
+  #   self.assertEqual(result["expand_stack"], ["subword", "word", "quotes", "semantic_unit", "symbols", "line"])
 
   def test_expand_to_symbol_from_line (self):
     result = expand(self.string3, 28, 37);
@@ -119,7 +127,7 @@ class JavascriptIntegrationTest(unittest.TestCase):
     self.assertEqual(result["start"], 23)
     self.assertEqual(result["end"], 55)
     self.assertEqual(result["type"], "quotes")
-    self.assertEqual(result["expand_stack"], ["word", "quotes"])
+    self.assertEqual(result["expand_stack"], ["subword", "word", "quotes"])
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/snippets/integration_01.txt
+++ b/test/snippets/integration_01.txt
@@ -1,1 +1,1 @@
-("foo bar" + "x")
+("foo_bar foo bar" + "x")


### PR DESCRIPTION
As suggested in https://github.com/aronwoost/sublime-expand-region/issues/26 this adds support for subwords/CamelHumps (in IntelliJ):

![expand_to_subword](https://cloud.githubusercontent.com/assets/12573621/11543235/d0726d98-993b-11e5-9a35-bc457d9ab471.gif)
 