### PR TITLE
Language detection based on the Buffer Syntax

### DIFF
--- a/ExpandRegion.py
+++ b/ExpandRegion.py
@@ -18,17 +18,19 @@ class ExpandRegionCommand(sublime_plugin.TextCommand):
         self.view.sel().add(sublime.Region(result["start"], result["end"]))
       return
 
-    extension = ""
-    if (self.view.file_name()):
-      name, fileex = os.path.splitext(self.view.file_name())
-      extension = fileex[1:]
+    language = ""
+    point = self.view.sel()[0].b
+    if self.view.score_selector(point, "text.html") or self.view.score_selector(point, "text.xml"):
+      language = "html"
+    elif self.view.score_selector(point, "text.tex"):
+      language = "tex"
 
     for region in self.view.sel():
       string = self.view.substr(sublime.Region(0, self.view.size()))
       start = region.begin()
       end = region.end()
 
-      result = expand_region_handler.expand(string, start, end, extension, self.view.settings())
+      result = expand_region_handler.expand(string, start, end, language, self.view.settings())
       if result:
         self.view.sel().add(sublime.Region(result["start"], result["end"]))
         if debug:

--- a/expand_region_handler.py
+++ b/expand_region_handler.py
@@ -9,11 +9,11 @@ except:
   from . import html
   from . import latex
 
-def expand(string, start, end, extension="", settings=None):
+def expand(string, start, end, language="", settings=None):
 
-  if(re.compile("html|htm|xml").search(extension)):
+  if language == "html":
     result = html.expand(string, start, end)
-  elif extension in ["tex", "tikz", "sty"]:
+  elif language == "tex":
     result = latex.expand(string, start, end)
   else:
     result = javascript.expand(string, start, end)


### PR DESCRIPTION
This changes the language detection to use the buffer syntax instead of the file extension. I think this is a more flexible, intuitive, and desired behavior. The advantages are
- it also works for buffers, which are not saved
- also works with other file extensions (especially xml is used with a lot of extension)
- I think it is the behavior one would expect