### PR TITLE
Python support

### DIFF
--- a/ExpandRegion.py
+++ b/ExpandRegion.py
@@ -7,32 +7,35 @@ except:
 
 class ExpandRegionCommand(sublime_plugin.TextCommand):
   def run(self, edit, undo=False, debug=True):
+    view = self.view
 
     if (undo):
-      string = self.view.substr(sublime.Region(0, self.view.size()))
-      start = self.view.sel()[0].begin()
-      end = self.view.sel()[0].end()
-      result = expand_region_handler.undo(string, start, end, self.view.settings())
+      string = view.substr(sublime.Region(0, view.size()))
+      start = view.sel()[0].begin()
+      end = view.sel()[0].end()
+      result = expand_region_handler.undo(string, start, end, view.settings())
       if (result):
-        self.view.sel().clear()
-        self.view.sel().add(sublime.Region(result["start"], result["end"]))
+        view.sel().clear()
+        view.sel().add(sublime.Region(result["start"], result["end"]))
       return
 
     language = ""
-    point = self.view.sel()[0].b
-    if self.view.score_selector(point, "text.html") or self.view.score_selector(point, "text.xml"):
+    point = view.sel()[0].b
+    if view.score_selector(point, "text.html") or view.score_selector(point, "text.xml"):
       language = "html"
-    elif self.view.score_selector(point, "text.tex"):
+    elif view.score_selector(point, "source.python") or view.score_selector(point, "source.cython"):
+      language = "python"
+    elif view.score_selector(point, "text.tex"):
       language = "tex"
 
-    for region in self.view.sel():
-      string = self.view.substr(sublime.Region(0, self.view.size()))
+    for region in view.sel():
+      string = view.substr(sublime.Region(0, view.size()))
       start = region.begin()
       end = region.end()
 
-      result = expand_region_handler.expand(string, start, end, language, self.view.settings())
+      result = expand_region_handler.expand(string, start, end, language, view.settings())
       if result:
-        self.view.sel().add(sublime.Region(result["start"], result["end"]))
+        view.sel().add(sublime.Region(result["start"], result["end"]))
         if debug:
           print("startIndex: {0}, endIndex: {1}, type: {2}".format(result["start"], result["end"], result["type"]))
 

--- a/expand_region_handler.py
+++ b/expand_region_handler.py
@@ -4,10 +4,12 @@ try:
   import javascript
   import html
   import latex
+  import python
 except:
   from . import javascript
   from . import html
   from . import latex
+  from . import python
 
 def expand(string, start, end, extension="", settings=None):
 
@@ -15,6 +17,8 @@ def expand(string, start, end, extension="", settings=None):
     result = html.expand(string, start, end)
   elif extension in ["tex", "tikz", "sty"]:
     result = latex.expand(string, start, end)
+  elif re.match(r"py.?", extension):
+    result = python.expand(string, start, end)
   else:
     result = javascript.expand(string, start, end)
 

--- a/expand_region_handler.py
+++ b/expand_region_handler.py
@@ -17,7 +17,7 @@ def expand(string, start, end, language="", settings=None):
     result = html.expand(string, start, end)
   elif language == "tex":
     result = latex.expand(string, start, end)
-  elif re.match(r"py.?", extension):
+  elif language == "python":
     result = python.expand(string, start, end)
   else:
     result = javascript.expand(string, start, end)

--- a/expand_to_indent.py
+++ b/expand_to_indent.py
@@ -1,0 +1,96 @@
+import re
+
+try:
+    import utils
+except:
+    from . import utils
+
+
+_INDENT_RE = re.compile(r"^(?P<spaces>\s*)")
+
+
+def empty_line(string, line):
+    return not string[line["start"]:line["end"]].strip()
+
+
+def get_indent(string, line):
+    line_str = string[line["start"]:line["end"]]
+    m = _INDENT_RE.match(line_str)
+    if m is None:  # should never happen
+        return 0
+    return len(m.group("spaces"))
+
+
+def _expand_to_indent(string, start, end):
+    line = utils.get_line(string, start, end)
+    indent = get_indent(string, line)
+    start = line["start"]
+    end = line["end"]
+    before_line = line
+    while True:
+        # get the line before
+        pos = before_line["start"] - 1
+        if pos <= 0:
+            break
+        before_line = utils.get_line(string, pos, pos)
+        before_indent = get_indent(string, before_line)
+        # done if the line has a lower indent
+        if not indent <= before_indent and not empty_line(string, before_line):
+            break
+        # if the indent equals the lines indent than update the start
+        if not empty_line(string, before_line) and indent == before_indent:
+            start = before_line["start"]
+
+    after_line = line
+    while True:
+        # get the line after
+        pos = after_line["end"] + 1
+        if pos >= len(string):
+            break
+        after_line = utils.get_line(string, pos, pos)
+        after_indent = get_indent(string, after_line)
+        # done if the line has a lower indent
+        if not indent <= after_indent and not empty_line(string, after_line):
+            break
+        # move the end
+        if not empty_line(string, after_line):
+            end = after_line["end"]
+
+    return utils.create_return_obj(start, end, string, "indent")
+
+
+def expand_to_indent(string, start, end):
+    result = _expand_to_indent(string, start, end)
+    if result["start"] == start and result["end"] == end:
+        return None
+    return result
+
+
+def py_expand_to_indent(string, start,
+                        end):
+    line = utils.get_line(string, start, end)
+    indent = get_indent(string, line)
+    # we don't expand to indent 0 (whole document)
+    if indent == 0:
+        return None
+    # expand to indent
+    result = _expand_to_indent(string, start, end)
+    if result is None:
+        return None
+    # get the intent of the first lin
+    # if the expansion changed return the result increased
+    if not(result["start"] == start and result["end"] == end):
+        return result
+    pos = result["start"] - 1
+    while True:
+        if pos < 0:
+            return None
+        # get the indent of the line before
+        before_line = utils.get_line(string, pos, pos)
+        before_indent = get_indent(string, before_line)
+        if not empty_line(string, before_line) and before_indent < indent:
+            start = before_line["start"]
+            end = result["end"]
+            return utils.create_return_obj(start, end, string, "py_indent")
+        # goto the line before the line befor
+        pos = before_line["start"] - 1

--- a/python.py
+++ b/python.py
@@ -1,0 +1,75 @@
+try:
+    import expand_to_indent
+    import javascript
+    import utils
+except:
+    from . import expand_to_indent
+    from . import javascript
+    from . import utils
+
+
+def expand(string, start, end):
+    expand_stack = []
+    result = javascript.expand(string, start, end)
+    if result:
+        return result
+
+    expand_stack.append("line_no_indent")
+    result = expand_line_without_indent(string, start, end)
+    if result:
+        result["expand_stack"] = expand_stack
+        return result
+
+    expand_stack.append("line_continuation")
+    result = expand_over_line_continuation(string, start, end)
+    if result:
+        return result
+
+    expand_stack.append("py_block_start")
+    result = expand_python_block_from_start(string, start, end)
+    if result:
+        result["expand_stack"] = expand_stack
+        return result
+
+    expand_stack.append("py_indent")
+    result = expand_to_indent.py_expand_to_indent(string, start, end)
+    if result:
+        result["expand_stack"] = expand_stack
+        return result
+
+
+def expand_over_line_continuation(string, start, end):
+    if not string[end-1:end] == "\\":
+        return None
+    line = utils.get_line(string, start, start)
+    next_line = utils.get_line(string, end + 1, end + 1)
+    start = line["start"]
+    end = next_line["end"]
+    next_result = expand_over_line_continuation(string, start, end)
+    # recursive check if there is an other continuation
+    if next_result:
+        start = next_result["start"]
+        end = next_result["end"]
+    return utils.create_return_obj(start, end, string, "line_continuation")
+
+
+def expand_python_block_from_start(string, start, end):
+    if string[end-1:end] != ":":
+        return None
+    result = expand_to_indent.expand_to_indent(string, end + 1,
+                                               end + 1)
+    if result:
+        # line = utils.get_line(string, start, start)
+        line = utils.get_line(string, start, start)
+        start = line["start"]
+        end = result["end"]
+        return utils.create_return_obj(start, end, string, "py_block_start")
+
+
+def expand_line_without_indent(string, start, end):
+    line = utils.get_line(string, start, end)
+    indent = expand_to_indent.get_indent(string, line)
+    lstart = min(start, line["start"] + indent)
+    lend = max(end, line["end"])
+    if lstart != start or lend != end:
+        return utils.create_return_obj(lstart, lend, string, "line_no_indent")

--- a/test/integration_python.py
+++ b/test/integration_python.py
@@ -1,0 +1,105 @@
+import unittest
+
+from expand_region_handler import *
+
+
+class PythonIntegrationTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        with open("test/snippets/python_01.txt", "r") as myfile:
+            self.string1 = myfile.read()
+        with open("test/snippets/python_02.txt", "r") as myfile:
+            self.string2 = myfile.read()
+
+    def test_expand_to_subword1(self):
+        result = expand(self.string1, 208, 208, "py")
+        self.assertEqual(result["start"], 206)
+        self.assertEqual(result["end"], 209)
+
+    def test_expand_to_word1(self):
+        result = expand(self.string1, 206, 209, "py")
+        self.assertEqual(result["start"], 206)
+        self.assertEqual(result["end"], 213)
+
+    def test_expand_to_parens1(self):
+        result = expand(self.string1, 206, 213, "py")
+        self.assertEqual(result["start"], 206)
+        self.assertEqual(result["end"], 218)
+
+    def test_expand_to_parens2(self):
+        result = expand(self.string1, 206, 218, "py")
+        self.assertEqual(result["start"], 205)
+        self.assertEqual(result["end"], 219)
+
+    def test_expand_to_semantic_unit1(self):
+        result = expand(self.string1, 205, 219, "py")
+        self.assertEqual(result["start"], 204)
+        self.assertEqual(result["end"], 219)
+
+    def test_expand_to_line1(self):
+        result = expand(self.string1, 204, 219, "py")
+        self.assertEqual(result["start"], 195)
+        self.assertEqual(result["end"], 219)
+
+    def test_expand_to_indent1(self):
+        result = expand(self.string1, 195, 219, "py")
+        self.assertEqual(result["start"], 183)
+        self.assertEqual(result["end"], 237)
+
+    def test_expand_to_indent2(self):
+        result = expand(self.string1, 183, 237, "py")
+        self.assertEqual(result["start"], 169)
+        self.assertEqual(result["end"], 237)
+
+    def test_expand_to_indent3(self):
+        result = expand(self.string1, 169, 237, "py")
+        self.assertEqual(result["start"], 90)
+        self.assertEqual(result["end"], 259)
+
+    def test_expand_to_indent4(self):
+        result = expand(self.string1, 90, 259, "py")
+        self.assertEqual(result["start"], 63)
+        self.assertEqual(result["end"], 259)
+
+    def test_expand_to_indent5(self):
+        result = expand(self.string1, 63, 259, "py")
+        self.assertEqual(result["start"], 63)
+        self.assertEqual(result["end"], 292)
+
+    def test_expand_to_indent6(self):
+        result = expand(self.string1, 63, 292, "py")
+        self.assertEqual(result["start"], 44)
+        self.assertEqual(result["end"], 292)
+
+    def test_expand_not_to_no_indent(self):
+        result = expand(self.string1, 44, 292, "py")
+        self.assertEqual(result, None)
+
+    def test_expand_from_block_start1(self):
+        result = expand(self.string1, 177, 182, "py")
+        self.assertEqual(result["start"], 169)
+        self.assertEqual(result["end"], 237)
+
+    def test_expand_from_block_start2(self):
+        result = expand(self.string1, 67, 89, "py")
+        self.assertEqual(result["start"], 63)
+        self.assertEqual(result["end"], 259)
+
+    def test_expand_from_block_start3(self):
+        result = expand(self.string1, 44, 62, "py")
+        self.assertEqual(result["start"], 44)
+        self.assertEqual(result["end"], 292)
+
+    def test_expand_over_line_cont1(self):
+        result = expand(self.string2, 16, 28, "py")
+        self.assertEqual(result["start"], 12)
+        self.assertEqual(result["end"], 81)
+
+    def test_expand_from_block_start4(self):
+        result = expand(self.string2, 12, 81, "py")
+        self.assertEqual(result["start"], 12)
+        self.assertEqual(result["end"], 116)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/integration_python.py
+++ b/test/integration_python.py
@@ -13,91 +13,91 @@ class PythonIntegrationTest(unittest.TestCase):
             self.string2 = myfile.read()
 
     def test_expand_to_subword1(self):
-        result = expand(self.string1, 208, 208, "py")
+        result = expand(self.string1, 208, 208, "python")
         self.assertEqual(result["start"], 206)
         self.assertEqual(result["end"], 209)
 
     def test_expand_to_word1(self):
-        result = expand(self.string1, 206, 209, "py")
+        result = expand(self.string1, 206, 209, "python")
         self.assertEqual(result["start"], 206)
         self.assertEqual(result["end"], 213)
 
     def test_expand_to_parens1(self):
-        result = expand(self.string1, 206, 213, "py")
+        result = expand(self.string1, 206, 213, "python")
         self.assertEqual(result["start"], 206)
         self.assertEqual(result["end"], 218)
 
     def test_expand_to_parens2(self):
-        result = expand(self.string1, 206, 218, "py")
+        result = expand(self.string1, 206, 218, "python")
         self.assertEqual(result["start"], 205)
         self.assertEqual(result["end"], 219)
 
     def test_expand_to_semantic_unit1(self):
-        result = expand(self.string1, 205, 219, "py")
+        result = expand(self.string1, 205, 219, "python")
         self.assertEqual(result["start"], 204)
         self.assertEqual(result["end"], 219)
 
     def test_expand_to_line1(self):
-        result = expand(self.string1, 204, 219, "py")
+        result = expand(self.string1, 204, 219, "python")
         self.assertEqual(result["start"], 195)
         self.assertEqual(result["end"], 219)
 
     def test_expand_to_indent1(self):
-        result = expand(self.string1, 195, 219, "py")
+        result = expand(self.string1, 195, 219, "python")
         self.assertEqual(result["start"], 183)
         self.assertEqual(result["end"], 237)
 
     def test_expand_to_indent2(self):
-        result = expand(self.string1, 183, 237, "py")
+        result = expand(self.string1, 183, 237, "python")
         self.assertEqual(result["start"], 169)
         self.assertEqual(result["end"], 237)
 
     def test_expand_to_indent3(self):
-        result = expand(self.string1, 169, 237, "py")
+        result = expand(self.string1, 169, 237, "python")
         self.assertEqual(result["start"], 90)
         self.assertEqual(result["end"], 259)
 
     def test_expand_to_indent4(self):
-        result = expand(self.string1, 90, 259, "py")
+        result = expand(self.string1, 90, 259, "python")
         self.assertEqual(result["start"], 63)
         self.assertEqual(result["end"], 259)
 
     def test_expand_to_indent5(self):
-        result = expand(self.string1, 63, 259, "py")
+        result = expand(self.string1, 63, 259, "python")
         self.assertEqual(result["start"], 63)
         self.assertEqual(result["end"], 292)
 
     def test_expand_to_indent6(self):
-        result = expand(self.string1, 63, 292, "py")
+        result = expand(self.string1, 63, 292, "python")
         self.assertEqual(result["start"], 44)
         self.assertEqual(result["end"], 292)
 
     def test_expand_not_to_no_indent(self):
-        result = expand(self.string1, 44, 292, "py")
+        result = expand(self.string1, 44, 292, "python")
         self.assertEqual(result, None)
 
     def test_expand_from_block_start1(self):
-        result = expand(self.string1, 177, 182, "py")
+        result = expand(self.string1, 177, 182, "python")
         self.assertEqual(result["start"], 169)
         self.assertEqual(result["end"], 237)
 
     def test_expand_from_block_start2(self):
-        result = expand(self.string1, 67, 89, "py")
+        result = expand(self.string1, 67, 89, "python")
         self.assertEqual(result["start"], 63)
         self.assertEqual(result["end"], 259)
 
     def test_expand_from_block_start3(self):
-        result = expand(self.string1, 44, 62, "py")
+        result = expand(self.string1, 44, 62, "python")
         self.assertEqual(result["start"], 44)
         self.assertEqual(result["end"], 292)
 
     def test_expand_over_line_cont1(self):
-        result = expand(self.string2, 16, 28, "py")
+        result = expand(self.string2, 16, 28, "python")
         self.assertEqual(result["start"], 12)
         self.assertEqual(result["end"], 81)
 
     def test_expand_from_block_start4(self):
-        result = expand(self.string2, 12, 81, "py")
+        result = expand(self.string2, 12, 81, "python")
         self.assertEqual(result["start"], 12)
         self.assertEqual(result["end"], 116)
 

--- a/test/snippets/python_01.txt
+++ b/test/snippets/python_01.txt
@@ -1,0 +1,18 @@
+import os
+
+def function():
+    return True
+
+class TestClass():
+    def method1(foo, bar):
+        # comment
+        if a:
+            b = c(d)
+        e = foo(bar, bar)
+        if e:
+            result = f(foo_bar, bar)
+            x = y
+        return result
+
+    def method2():
+        pass

--- a/test/snippets/python_02.txt
+++ b/test/snippets/python_02.txt
@@ -1,0 +1,9 @@
+
+def foo():
+    if test and\
+            other_text and \
+            third_test:
+        x = y
+        y = foo(bar)
+    else:
+        c = d

--- a/test/test.py
+++ b/test/test.py
@@ -11,6 +11,7 @@ from . import units_xml_helper
 from . import integration_javascript
 from . import integration_html
 from . import integration_latex
+from . import integration_python
 
 if __name__ == "__main__":
   test_loader = unittest.TestLoader()
@@ -31,5 +32,6 @@ if __name__ == "__main__":
   suite.addTests(test_loader.loadTestsFromTestCase(integration_javascript.JavascriptIntegrationTest))
   suite.addTests(test_loader.loadTestsFromTestCase(integration_html.HtmlIntegrationTest))
   suite.addTests(test_loader.loadTestsFromTestCase(integration_latex.LatexIntegrationTest))
+  suite.addTests(test_loader.loadTestsFromTestCase(integration_python.PythonIntegrationTest))
 
   unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Support for the python programming language.
This first used the javascript expansion until it no longer matches and than adds an indendation based expansion for python on top and handles special cases, e.g. a selection of the start of a block:
``` py
|if condition:|
    do_something
```

Expansion order is:

1. use javascript expansion (...)
2. select line without indent
3. check special cases
  - line ends with `\` => select next line (continuation)
  - line ends with `:` => select following indendation block
3. select indendation
4. select block start before indendation

__Demonstration__
![expand_python_example](https://cloud.githubusercontent.com/assets/12573621/11763466/a55ccc34-a10b-11e5-92e8-71c5a827db2c.gif)