### PR TITLE
Unicode words (support for special chars like ä, ö,...)

### DIFF
--- a/expand_to_subword.py
+++ b/expand_to_subword.py
@@ -23,7 +23,20 @@ def expand_to_subword(string, start, end):
     upper = re.compile(r"[A-Z]")
     if upper.match(string[result["start"]-1:result["start"]]):
         result["start"] -= 1
+    # check that it is a "true" subword, i.e. inside a word
+    if not _is_true_subword(string, result):
+        return None
     return result
+
+
+def _is_true_subword(string, result):
+    start = result["start"]
+    end = result["end"]
+    char_before = string[start-1:start]
+    char_after = string[end:end+1]
+    is_word_before = re.match(r"[a-z0-9_]", char_before, re.IGNORECASE)
+    is_word_after = re.match(r"[a-z0-9_]", char_after, re.IGNORECASE)
+    return bool(is_word_before or is_word_after)
 
 
 def _is_inside_upper(string, start, end):

--- a/expand_to_word.py
+++ b/expand_to_word.py
@@ -6,6 +6,6 @@ except:
   from . import expand_to_regex_set
 
 def expand_to_word(string, startIndex, endIndex):
-  regex = re.compile("[a-zA-Z0-9_$]");
+  regex = re.compile(r"[\w$]", re.UNICODE);
 
   return expand_to_regex_set._expand_to_regex_rule(string, startIndex, endIndex, regex, "word")

--- a/test/snippets/word_03.txt
+++ b/test/snippets/word_03.txt
@@ -1,0 +1,1 @@
+ExpandRegion unterstützt jetzt deutsche Sonderzeichen in Wörtern, daß kann vorzüglich für Texte genutzt werden

--- a/test/units_expand_to_word.py
+++ b/test/units_expand_to_word.py
@@ -10,6 +10,9 @@ class WordTest(unittest.TestCase):
       self.string1 = myfile.read()
     with open ("test/snippets/word_02.txt", "r") as myfile:
       self.string2 = myfile.read()
+    with open ("test/snippets/word_03.txt", "r") as myfile:
+      # decode utf8 unicode
+      self.string3 = myfile.read().decode("utf8")
 
   def test_word_with_whitespaces_around (self):
     result = expand_to_word(" hello ", 3, 3);
@@ -50,6 +53,26 @@ class WordTest(unittest.TestCase):
   def test_dont_expand_to_linebreak (self):
     result = expand_to_word(self.string2, 0, 0);
     self.assertEqual(result, None)
+
+  def test_special_chars1(self):
+    result = expand_to_word(self.string3, 15, 15)
+    self.assertEqual(result["start"], 13)
+    self.assertEqual(result["end"], 24)
+
+  def test_special_chars2(self):
+    result = expand_to_word(self.string3, 57, 57)
+    self.assertEqual(result["start"], 57)
+    self.assertEqual(result["end"], 64)
+
+  def test_special_chars3(self):
+    result = expand_to_word(self.string3, 75, 77)
+    self.assertEqual(result["start"], 75)
+    self.assertEqual(result["end"], 85)
+
+  def test_special_chars4(self):
+    result = expand_to_word(self.string3, 89, 89)
+    self.assertEqual(result["start"], 86)
+    self.assertEqual(result["end"], 89)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
This pull request contains two changes:
- `expand_to_word` also matches special language characters like ä, ö and ü
- `expand_to_subword` won't select whole words (I think this is better and 
unicode support for subwords is more complicated)

This will partially solve https://github.com/aronwoost/sublime-expand-region/issues/32 and some non-english writers might benefit from it.

![expand_special_chars](https://cloud.githubusercontent.com/assets/12573621/11791648/532983ce-a2a2-11e5-99a1-db436c2baa2c.gif)
