### PR TITLE
Little rework of html expansion

### DIFF
--- a/expand_to_xml_node.py
+++ b/expand_to_xml_node.py
@@ -24,9 +24,15 @@ def expand_to_xml_node(string, start, end):
     # else it's self closing and there is no matching tag
 
   # check if current selection is within a tag, if it is expand to the tag
+  # first expand to inside the tag and then to the whole tag
   is_within_tag_result = is_within_tag(string, start, end)
-  if(is_within_tag_result):
-    return utils.create_return_obj(is_within_tag_result["start"], is_within_tag_result["end"], string, "complete_node")
+  if is_within_tag_result:
+    inner_start = is_within_tag_result["start"] + 1
+    inner_end = is_within_tag_result["end"] - 1
+    if start == inner_start and end == inner_end:
+      return utils.create_return_obj(is_within_tag_result["start"], is_within_tag_result["end"], string, "complete_node")
+    else:
+      return utils.create_return_obj(inner_start, inner_end, string, "inner_node")
   # expand selection to the "parent" node of the current selection
   stringStartToSelectionStart = string[:start]
   parent_opening_tag = find_tag(stringStartToSelectionStart, "backward")

--- a/expand_to_xml_node.py
+++ b/expand_to_xml_node.py
@@ -6,47 +6,45 @@ except:
   from . import utils
 
 def expand_to_xml_node(string, start, end):
+  tag_properties = get_tag_properties(string[start:end])
+  # if we are selecting a tag, then select the matching tag
+  if tag_properties:
+    tag_name = tag_properties["name"]
+    if tag_properties["type"] == "closing":
+      stringStartToTagStart = string[:start]
+      openingTagPosition = find_tag(stringStartToTagStart, "backward", tag_name)
+      if openingTagPosition:
+        return utils.create_return_obj(openingTagPosition["start"], end, string, "complete_node")
+    # if it's a opening tag, find opening tag and return positions
+    elif tag_properties["type"] == "opening":
+      stringNodeEndToStringEnd = string[end:]
+      closingTagPosition = find_tag(stringNodeEndToStringEnd, "forward", tag_name)
+      if closingTagPosition:
+        return utils.create_return_obj(start, end + closingTagPosition["end"], string, "complete_node")
+    # else it's self closing and there is no matching tag
 
-  # check if current selection is with a tag
+  # check if current selection is within a tag, if it is expand to the tag
   is_within_tag_result = is_within_tag(string, start, end)
   if(is_within_tag_result):
-    # save string of tag
-    tagString = string[is_within_tag_result["start"]:is_within_tag_result["end"]]
-    # get tag name and if it's a opening or closing tag
-    getTagNameResult = get_tag_properties(tagString)
-    tagName = getTagNameResult["name"]
-    # if it's a closing tag, find opening tag and return positions
-    if(getTagNameResult["type"] == "closing"):
-      stringStartToTagStart = string[0:is_within_tag_result["start"]]
-      openingTagPosition = find_tag(stringStartToTagStart, "backward", tagName)
-      return utils.create_return_obj(openingTagPosition["start"], is_within_tag_result["end"], string, "complete_node")
-    # it's self closing, just use it, no need to look further
-    elif(getTagNameResult["type"] == "self_closing"):
-      return utils.create_return_obj(is_within_tag_result["start"], is_within_tag_result["end"], string, "complete_node")
-    # if it's a opening tag, find opening tag and return positions
-    else:
-      stringNodeEndToStringEnd = string[is_within_tag_result["end"]:]
-      closingTagPosition = find_tag(stringNodeEndToStringEnd, "forward", tagName)
-      return utils.create_return_obj(is_within_tag_result["start"], is_within_tag_result["end"] + closingTagPosition["end"], string, "complete_node")
-
+    return utils.create_return_obj(is_within_tag_result["start"], is_within_tag_result["end"], string, "complete_node")
   # expand selection to the "parent" node of the current selection
-  stringStartToSelectionStart = string[0:end]
+  stringStartToSelectionStart = string[:start]
   parent_opening_tag = find_tag(stringStartToSelectionStart, "backward")
   if(parent_opening_tag):
     # find closing tag
     stringNodeEndToStringEnd = string[parent_opening_tag["end"]:]
     closingTagPosition = find_tag(stringNodeEndToStringEnd, "forward", parent_opening_tag["name"])
+    if closingTagPosition:
+      # set positions to content of node, w/o the node tags
+      newStart = parent_opening_tag["end"]
+      newEnd = parent_opening_tag["end"] + closingTagPosition["start"]
 
-    # set positions to content of node, w/o the node tags
-    newStart = parent_opening_tag["end"]
-    newEnd = parent_opening_tag["end"] + closingTagPosition["start"]
+      # if this is the current selection, set positions to content of node including start and end tags
+      if(newStart == start and newEnd == end):
+        newStart = parent_opening_tag["start"]
+        newEnd = parent_opening_tag["end"] + closingTagPosition["end"]
 
-    # if this is the current selection, set positions to content of node including start and end tags
-    if(newStart == start and newEnd == end):
-      newStart = parent_opening_tag["start"]
-      newEnd = parent_opening_tag["end"] + closingTagPosition["end"]
-
-    return utils.create_return_obj(newStart, newEnd, string, "parent_node_content")
+      return utils.create_return_obj(newStart, newEnd, string, "parent_node_content")
 
 def is_within_tag(string, startIndex, endIndex):
   openingRe = re.compile("<");
@@ -85,30 +83,39 @@ def is_within_tag(string, startIndex, endIndex):
 
 # returns tag name and if tag has a closing slash
 def get_tag_properties(string):
-  regex = re.compile("<\s*(\/*)\s*(\S*)(?:.*?)(\/*)\s*>")
+  regex = re.compile(
+    r"<\s*"
+    r"(?P<closing>\/?)\s*"
+    r"(?P<name>[^\s\/]*)\s*"
+    r"(?:.*?)"
+    r"(?P<self_closing>\/?)\s*"
+    r">"
+  )
   result = regex.match(string)
+  if not result:
+    return None
 
-  tag_name = result.group(2)
+  tag_name = result.group("name")
 
   void_elements = ["area", "base", "br", "col", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr"]
 
-  if(result.group(1) == "/"):
+  if result.group("closing"):
     tag_type = "closing"
-  elif(result.group(3) == "/"):
+  elif result.group("self_closing"):
     tag_type = "self_closing"
   elif(tag_name in void_elements):
     tag_type = "self_closing"
   else:
     tag_type = "opening"
 
-  return {"name": result.group(2), "type": tag_type}
+  return {"name": tag_name, "type": tag_type}
 
 def find_tag(string, direction, tag_name=""):
   # search for opening and closing tag with a tag_name. If tag_name = "", search
   # for all tags.
   regexString = "<\s*" + tag_name + ".*?>|<\/\s*" + tag_name + "\s*>"
   regex = re.compile(regexString)
-  
+
   # direction == "forward" implies that we are looking for closing tags (and
   # vice versa
   target_tag_type = (direction == "forward" and "closing" or "opening")
@@ -126,10 +133,14 @@ def find_tag(string, direction, tag_name=""):
     result.reverse()
 
   for m in result:
-    tag_type = get_tag_properties(m.group())["type"]
+    tag_string = m.group()
+    # ignore comments
+    if tag_string.startswith("<!--"):
+      continue
+    tag_type = get_tag_properties(tag_string)["type"]
     if(tag_type == target_tag_type):
       if(len(symbolStack) == 0):
-        return {"start": m.start(), "end": m.end(), "name": get_tag_properties(m.group())["name"]}
+        return {"start": m.start(), "end": m.end(), "name": get_tag_properties(tag_string)["name"]}
       symbolStack.pop()
     elif(tag_type == target_tag_type_counterpart):
       symbolStack.append(tag_type)

--- a/test/integration_html.py
+++ b/test/integration_html.py
@@ -9,18 +9,33 @@ class HtmlIntegrationTest(unittest.TestCase):
     with open ("test/snippets/html_01.txt", "r") as myfile:
       self.string1 = myfile.read()
 
-  def test_expand_to_complete_node1 (self):
+  def test_expand_to_head_of_node1 (self):
     result = expand("  <div>test</div>", 3, 6, "html")
+    self.assertEqual(result["start"], 2)
+    self.assertEqual(result["end"], 7)
+
+  def test_expand_to_head_of_node2 (self):
+    result = expand(self.string1, 11, 15, "html")
+    self.assertEqual(result["start"], 8)
+    self.assertEqual(result["end"], 20)
+
+  def test_expand_to_head_of_node3 (self):
+    result = expand(self.string1, 162, 164, "html")
+    self.assertEqual(result["start"], 160)
+    self.assertEqual(result["end"], 165)
+
+  def test_expand_to_complete_node1 (self):
+    result = expand("  <div>test</div>", 2, 7, "html")
     self.assertEqual(result["start"], 2)
     self.assertEqual(result["end"], 17)
 
   def test_expand_to_complete_node2 (self):
-    result = expand(self.string1, 11, 15, "html")
+    result = expand(self.string1, 8, 20, "html")
     self.assertEqual(result["start"], 8)
     self.assertEqual(result["end"], 172)
 
   def test_expand_to_complete_node3 (self):
-    result = expand(self.string1, 162, 164, "html")
+    result = expand(self.string1, 160, 165, "html")
     self.assertEqual(result["start"], 152)
     self.assertEqual(result["end"], 165)
 

--- a/test/integration_html.py
+++ b/test/integration_html.py
@@ -9,18 +9,28 @@ class HtmlIntegrationTest(unittest.TestCase):
     with open ("test/snippets/html_01.txt", "r") as myfile:
       self.string1 = myfile.read()
 
+  def test_expand_to_inner_head_of_node2 (self):
+    result = expand(self.string1, 11, 15, "html")
+    self.assertEqual(result["start"], 9)
+    self.assertEqual(result["end"], 19)
+
+  def test_expand_to_inner_head_of_node3 (self):
+    result = expand(self.string1, 162, 164, "html")
+    self.assertEqual(result["start"], 161)
+    self.assertEqual(result["end"], 164)
+
   def test_expand_to_head_of_node1 (self):
     result = expand("  <div>test</div>", 3, 6, "html")
     self.assertEqual(result["start"], 2)
     self.assertEqual(result["end"], 7)
 
   def test_expand_to_head_of_node2 (self):
-    result = expand(self.string1, 11, 15, "html")
+    result = expand(self.string1, 9, 19, "html")
     self.assertEqual(result["start"], 8)
     self.assertEqual(result["end"], 20)
 
   def test_expand_to_head_of_node3 (self):
-    result = expand(self.string1, 162, 164, "html")
+    result = expand(self.string1, 161, 164, "html")
     self.assertEqual(result["start"], 160)
     self.assertEqual(result["end"], 165)
 
@@ -49,13 +59,23 @@ class HtmlIntegrationTest(unittest.TestCase):
     self.assertEqual(result["start"], 8)
     self.assertEqual(result["end"], 172)
 
-  def test_expand_to_self_closing_node1 (self):
+  def test_expand_to_inner_self_closing_node1 (self):
     result = expand("<input value='test'>", 1, 6, "html")
+    self.assertEqual(result["start"], 1)
+    self.assertEqual(result["end"], 19)
+
+  def test_expand_to_inner_self_closing_node2 (self):
+    result = expand("<magic value='test' />", 1, 6, "html")
+    self.assertEqual(result["start"], 1)
+    self.assertEqual(result["end"], 21)
+
+  def test_expand_to_self_closing_node1 (self):
+    result = expand("<input value='test'>", 1, 19, "html")
     self.assertEqual(result["start"], 0)
     self.assertEqual(result["end"], 20)
 
   def test_expand_to_self_closing_node2 (self):
-    result = expand("<magic value='test' />", 1, 6, "html")
+    result = expand("<magic value='test' />", 1, 21, "html")
     self.assertEqual(result["start"], 0)
     self.assertEqual(result["end"], 22)
 


### PR DESCRIPTION
This pull request does
- improve tolerance (e.g. for unmatching tags)
- comments are now ignored when searching tags
- added a step in between, when expanding from inside a tag, which is the only behavior change. This selects the tag header before selecting the whole body.