### PR TITLE
User definable language selection and better scope granularity

### DIFF
--- a/ExpandRegion.py
+++ b/ExpandRegion.py
@@ -6,7 +6,7 @@ except:
   from . import expand_region_handler
 
 class ExpandRegionCommand(sublime_plugin.TextCommand):
-  def run(self, edit, undo=False, debug=True):
+  def run(self, edit, language="", undo=False, debug=True):
     view = self.view
 
     if (undo):
@@ -19,14 +19,19 @@ class ExpandRegionCommand(sublime_plugin.TextCommand):
         view.sel().add(sublime.Region(result["start"], result["end"]))
       return
 
-    language = ""
-    point = view.sel()[0].b
-    if view.score_selector(point, "text.html") or view.score_selector(point, "text.xml"):
-      language = "html"
-    elif view.score_selector(point, "source.python") or view.score_selector(point, "source.cython"):
-      language = "python"
-    elif view.score_selector(point, "text.tex"):
-      language = "tex"
+    if not language:
+      point = view.sel()[0].b
+      settings = sublime.load_settings("ExpandRegion.sublime-settings")
+      selectors = settings.get("scope_selectors")
+      def maximal_score(scopes):
+        return max(view.score_selector(point, s) for s in scopes)
+      # calculate the maximal score for each language
+      scores = [(k, maximal_score(v)) for k, v in selectors.items()]
+      # get the language with the best score
+      scored_lang, score = max(scores, key=lambda item: item[1])
+      language = scored_lang if score else ""
+    if debug:
+      print("Determined language: '{0}'".format(language))
 
     for region in view.sel():
       string = view.substr(sublime.Region(0, view.size()))

--- a/ExpandRegion.sublime-settings
+++ b/ExpandRegion.sublime-settings
@@ -5,26 +5,17 @@
     //  e.g. python can be used for indendation based language
     //       javascript for other C-like languages
     // The scope which fits the best to the current cursor context will be selected.
+    // available languages:
+    //  - "javascript"
+    //  - "python"
+    //  - "html"
+    //  - "latex"
     "scope_selectors":
     {
-        "javascript":
-        [
-            "source.js",
-            "markup.raw.block.fenced.markdown"
-        ],
-        "python":
-        [
-            "source.python",
-            "source.cython"
-        ],
-        "html":
-        [
-            "text.html",
-            "text.xml"
-        ],
-        "latex":
-        [
-            "text.tex"
-        ]
+        // example: use python in yaml files
+        // "python":
+        // [
+        //     "source.yaml"
+        // ]
     }
 }

--- a/ExpandRegion.sublime-settings
+++ b/ExpandRegion.sublime-settings
@@ -1,0 +1,30 @@
+{
+    // The selectors for the different languages.
+    // This specifies a list of scopes for every supported language.
+    // If the intended language is not supported you may chose the language, which fits best,
+    //  e.g. python can be used for indendation based language
+    //       javascript for other C-like languages
+    // The scope which fits the best to the current cursor context will be selected.
+    "scope_selectors":
+    {
+        "javascript":
+        [
+            "source.js",
+            "markup.raw.block.fenced.markdown"
+        ],
+        "python":
+        [
+            "source.python",
+            "source.cython"
+        ],
+        "html":
+        [
+            "text.html",
+            "text.xml"
+        ],
+        "latex":
+        [
+            "text.tex"
+        ]
+    }
+}

--- a/ExpandRegionFallback.sublime-settings
+++ b/ExpandRegionFallback.sublime-settings
@@ -1,0 +1,33 @@
+{
+    "scope_selectors":
+    {
+        "javascript":
+        [
+            "source.js",
+            "source.java",
+            "source.cs",
+            "source.c++",
+            "source.php",
+            "source.sublime-settings",
+            "markup.raw.block.fenced.markdown"
+        ],
+        "python":
+        [
+            "source.python",
+            "source.cython",
+            "source.coffee",
+            "source.haskell",
+            "source.yaml",
+            "source.sass"
+        ],
+        "html":
+        [
+            "text.html",
+            "text.xml"
+        ],
+        "latex":
+        [
+            "text.tex"
+        ]
+    }
+}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,38 @@
+[
+	{
+		"caption": "Preferences",
+		"id": "preferences",
+		"mnemonic": "n",
+		"children":
+		[
+			{
+				"caption": "Package Settings",
+				"id": "package-settings",
+				"mnemonic": "P",
+				"children":
+				[
+					{
+						"caption": "ExpandRegion",
+						"children":
+						[
+							{
+								"caption": "Settings – Default",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/ExpandRegion/ExpandRegion.sublime-settings"
+								}
+							},
+							{
+								"caption": "Settings – User",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/User/ExpandRegion.sublime-settings"
+								}
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+]

--- a/expand_region_handler.py
+++ b/expand_region_handler.py
@@ -15,7 +15,7 @@ def expand(string, start, end, language="", settings=None):
 
   if language == "html":
     result = html.expand(string, start, end)
-  elif language == "tex":
+  elif language == "latex":
     result = latex.expand(string, start, end)
   elif language == "python":
     result = python.expand(string, start, end)

--- a/test/integration_latex.py
+++ b/test/integration_latex.py
@@ -11,97 +11,97 @@ class LatexIntegrationTest(unittest.TestCase):
             self.string1 = myfile.read()
 
     def test_expand_to_word1(self):
-        result = expand("\\section*{My Section}", 3, 3, "tex")
+        result = expand("\\section*{My Section}", 3, 3, "latex")
         self.assertEqual(result["start"], 1)
         self.assertEqual(result["end"], 8)
 
     def test_expand_to_word2(self):
-        result = expand(self.string1, 243, 246, "tex")
+        result = expand(self.string1, 243, 246, "latex")
         self.assertEqual(result["start"], 242)
         self.assertEqual(result["end"], 248)
 
     def test_expand_to_command_base1(self):
-        result = expand("\\textbf{My Text}", 1, 7, "tex")
+        result = expand("\\textbf{My Text}", 1, 7, "latex")
         self.assertEqual(result["start"], 0)
         self.assertEqual(result["end"], 7)
 
     def test_expand_to_command_base2(self):
-        result = expand("\\section*{My Section}", 1, 8, "tex")
+        result = expand("\\section*{My Section}", 1, 8, "latex")
         self.assertEqual(result["start"], 0)
         self.assertEqual(result["end"], 9)
 
     def test_expand_to_command_base3(self):
-        result = expand(self.string1, 242, 248, "tex")
+        result = expand(self.string1, 242, 248, "latex")
         self.assertEqual(result["start"], 241)
         self.assertEqual(result["end"], 248)
 
     def test_expand_to_command_args1(self):
-        result = expand(self.string1, 241, 248, "tex")
+        result = expand(self.string1, 241, 248, "latex")
         self.assertEqual(result["start"], 241)
         self.assertEqual(result["end"], 254)
 
     def test_expand_to_command_args2(self):
-        result = expand(self.string1, 213, 223, "tex")
+        result = expand(self.string1, 213, 223, "latex")
         self.assertEqual(result["start"], 213)
         self.assertEqual(result["end"], 255)
 
     def test_expand_to_semantic_unit1(self):
-        result = expand(self.string1, 249, 253, "tex")
+        result = expand(self.string1, 249, 253, "latex")
         self.assertEqual(result["start"], 248)
         self.assertEqual(result["end"], 254)
 
     def test_expand_to_semantic_unit2(self):
-        result = expand(self.string1, 229, 254, "tex")
+        result = expand(self.string1, 229, 254, "latex")
         self.assertEqual(result["start"], 228)
         self.assertEqual(result["end"], 255)
 
     def test_expand_to_surrounding_command1(self):
-        result = expand(self.string1, 248, 254, "tex")
+        result = expand(self.string1, 248, 254, "latex")
         self.assertEqual(result["start"], 241)
         self.assertEqual(result["end"], 254)
 
     def test_expand_to_surrounding_command2(self):
-        result = expand(self.string1, 228, 255, "tex")
+        result = expand(self.string1, 228, 255, "latex")
         self.assertEqual(result["start"], 213)
         self.assertEqual(result["end"], 255)
 
     def test_expand_to_matching_env1(self):
-        result = expand(self.string1, 114, 129, "tex")
+        result = expand(self.string1, 114, 129, "latex")
         self.assertEqual(result["start"], 114)
         self.assertEqual(result["end"], 294)
 
     def test_expand_to_matching_env2(self):
-        result = expand(self.string1, 281, 294, "tex")
+        result = expand(self.string1, 281, 294, "latex")
         self.assertEqual(result["start"], 114)
         self.assertEqual(result["end"], 294)
 
     def test_expand_to_env1(self):
-        result = expand(self.string1, 176, 176, "tex")
+        result = expand(self.string1, 176, 176, "latex")
         self.assertEqual(result["start"], 174)
         self.assertEqual(result["end"], 193)
 
     def test_expand_to_env2(self):
-        result = expand(self.string1, 174, 193, "tex")
+        result = expand(self.string1, 174, 193, "latex")
         self.assertEqual(result["start"], 159)
         self.assertEqual(result["end"], 206)
 
     def test_expand_to_env3(self):
-        result = expand(self.string1, 213, 255, "tex")
+        result = expand(self.string1, 213, 255, "latex")
         self.assertEqual(result["start"], 129)
         self.assertEqual(result["end"], 281)
 
     def test_expand_to_env4(self):
-        result = expand(self.string1, 129, 281, "tex")
+        result = expand(self.string1, 129, 281, "latex")
         self.assertEqual(result["start"], 114)
         self.assertEqual(result["end"], 294)
 
     def test_expand_to_env5(self):
-        result = expand(self.string1, 114, 294, "tex")
+        result = expand(self.string1, 114, 294, "latex")
         self.assertEqual(result["start"], 89)
         self.assertEqual(result["end"], 297)
 
     def test_expand_to_env6(self):
-        result = expand(self.string1, 89, 297, "tex")
+        result = expand(self.string1, 89, 297, "latex")
         self.assertEqual(result["start"], 73)
         self.assertEqual(result["end"], 311)
 


### PR DESCRIPTION
This pull request contains:
- settings (file and adds the usual stuff into the menu)
- user definable language scope selectors
- better scope granularity

Now it is possible to define the language selections in the setting. Therefore it is easy to select similar languages without changing the source code. (e.g. one can easy add `yaml` to be treated as `python`, because both is indent based).
To archive this all selectors are scored (by the ST api) and the language with the maximum score is selected.

The settings are defined as in this example:
``` js
"scope_selectors":
{
    // ...
    "python":
    [
        "source.python",
        "source.cython",
        "source.coffee",
        "source.yaml"
    ],
    "html":
    [
        "text.html",
        "text.xml"
    ]
    // ...
}
```

The advantage of defining it in the settings is that we don't have to hard-code every case and it is more flexible, better extend-able, and better readable.
The advantage of the maximum score is, that it also works in nested scopes as used in php, html and so on (this has been requested in https://github.com/aronwoost/sublime-expand-region/issues/55). It is demonstrated in this gifs:

- python inside LaTeX:<br />
  ![expand_latex_python](https://cloud.githubusercontent.com/assets/12573621/11900596/43e9ce66-a5a7-11e5-9adf-6f42786a8977.gif)
- javascript inside html: <br />
  ![expand_html_js](https://cloud.githubusercontent.com/assets/12573621/11900602/48831518-a5a7-11e5-93a0-7edaf1962616.gif)

The drawback of relying on the ST api are the missing unit test, because I don't see a way to test it with travis.