### PR TITLE
Force Soft-Undo integration

### DIFF
--- a/ExpandRegion.py
+++ b/ExpandRegion.py
@@ -89,8 +89,8 @@ class ExpandRegionCommand(sublime_plugin.TextCommand):
     for sel in new_regions:
       view.sel().add(sel)
 
-    # TODO take this from the settings
-    do_force_enable_soft_undo = True
+    settings = sublime.load_settings("ExpandRegion.sublime-settings")
+    do_force_enable_soft_undo = settings.get("force_soft_undo_integration")
     if do_force_enable_soft_undo:
       _force_enable_soft_undo(view, edit, new_regions)
 

--- a/ExpandRegion.sublime-settings
+++ b/ExpandRegion.sublime-settings
@@ -1,4 +1,8 @@
 {
+    // Whether ExpandRegion should force himself into the soft-undo list.
+    // Try to set this to false, if you encounter problems.
+    "force_soft_undo_integration": true,
+
     // The selectors for the different languages.
     // This specifies a list of scopes for every supported language.
     // If the intended language is not supported you may chose the language, which fits best,


### PR DESCRIPTION
This pull request forces the entry in the soft-undo history based on the suggestion of @bizoo in https://github.com/aronwoost/sublime-expand-region/issues/39. This will also add multi-cursor undo support as suggested in  https://github.com/aronwoost/sublime-expand-region/issues/40.

Beside from the multi-cursor support the other advantage is the continuation of soft-undo before the first expansion (currently you can only soft-undo until the first `expand_region`-call).

Since ST3 should integrate into soft-undo without doing something special, this code is hacky and just calls api methods to enforce the entry in the soft-undo history. Hence I would implement it as opt-out and add a setting to disable it. However it should be tested all OS/ST combinations to ensure it works for everyone.

Tested on

- [x] Windows ST3
- [x] Windows ST2
- [x] Linux ST3
- [x] Linux ST2
- [x] OSX ST3
- [x] OSX ST2


This is a suggestion to discuss whether to add this or not / add it as opt-in or opt-out.