### PR TITLE
Cooperate with BracketHighlighter

### DIFF
--- a/ExpandRegion.py
+++ b/ExpandRegion.py
@@ -96,33 +96,33 @@ class ExpandRegionCommand(sublime_plugin.TextCommand):
           print("startIndex: {0}, endIndex: {1}, type: {2}".format(result["start"], result["end"], result["type"]))
         result = sublime.Region(result["start"], result["end"])
 
-    # if we are on ST2 or have no BracketHighlighter regions only work
-    # with the result
-    if not _ST3 or not bh_regions:
-      if result:
-        new_regions.append(result)
-      else:
-        # if there is no result, keep the current region
-        new_regions.append(region)
-    else:
-      try:
-        inner, outer = next(
-          r for r in bh_regions
-          if r[1].contains(region) and
-          (region == r[0] or not region.contains(r[0]))
-        )
-        if inner == region:
-          new_regions.append(outer)
-        elif not result or (
-            inner.begin() > result.begin() or inner.end() < result.end()):
-          new_regions.append(inner)
-        else:
+      # if we are on ST2 or have no BracketHighlighter regions only work
+      # with the result
+      if not _ST3 or not bh_regions:
+        if result:
           new_regions.append(result)
-      except StopIteration:
-        if not result:
+        else:
           # if there is no result, keep the current region
-          result = region
-        new_regions.append(result)
+          new_regions.append(region)
+      else:
+        try:
+          inner, outer = next(
+            r for r in bh_regions
+            if r[1].contains(region) and
+            (region == r[0] or not region.contains(r[0]))
+          )
+          if inner == region:
+            new_regions.append(outer)
+          elif not result or (
+              inner.begin() > result.begin() or inner.end() < result.end()):
+            new_regions.append(inner)
+          else:
+            new_regions.append(result)
+        except StopIteration:
+          if not result:
+            # if there is no result, keep the current region
+            result = region
+          new_regions.append(result)
 
     # replace the selections with the new regions
     view.sel().clear()

--- a/ExpandRegion.py
+++ b/ExpandRegion.py
@@ -50,7 +50,7 @@ def _detect_language(view, settings_name):
 
 
 class ExpandRegionCommand(sublime_plugin.TextCommand):
-  def run(self, edit, language="", undo=False, debug=True):
+  def run(self, edit, language="", undo=False, debug=False):
     view = self.view
 
     if (undo):
@@ -69,6 +69,21 @@ class ExpandRegionCommand(sublime_plugin.TextCommand):
     if debug:
       print("Determined language: '{0}'".format(language))
 
+
+    # extract the locations from BracketHighlighter
+    locations = view.settings().get("bracket_highlighter.locations", {})
+    bh_regions = []
+    if _ST3:
+      for k, v in locations.get("open", {}).items():
+        r_open = sublime.Region(*v)
+        loc_close = locations.get("close", {})
+        if k not in loc_close:
+          continue
+        close = loc_close[k]
+        inner = sublime.Region(v[1], close[0])
+        outer = sublime.Region(v[0], close[1])
+        bh_regions.append((inner, outer))
+
     new_regions = []
     for region in self.view.sel():
       string = self.view.substr(sublime.Region(0, self.view.size()))
@@ -77,12 +92,37 @@ class ExpandRegionCommand(sublime_plugin.TextCommand):
 
       result = expand_region_handler.expand(string, start, end, language, self.view.settings())
       if result:
-        new_regions.append(sublime.Region(result["start"], result["end"]))
         if debug:
           print("startIndex: {0}, endIndex: {1}, type: {2}".format(result["start"], result["end"], result["type"]))
+        result = sublime.Region(result["start"], result["end"])
+
+    # if we are on ST2 or have no BracketHighlighter regions only work
+    # with the result
+    if not _ST3 or not bh_regions:
+      if result:
+        new_regions.append(result)
       else:
         # if there is no result, keep the current region
         new_regions.append(region)
+    else:
+      try:
+        inner, outer = next(
+          r for r in bh_regions
+          if r[1].contains(region) and
+          (region == r[0] or not region.contains(r[0]))
+        )
+        if inner == region:
+          new_regions.append(outer)
+        elif not result or (
+            inner.begin() > result.begin() or inner.end() < result.end()):
+          new_regions.append(inner)
+        else:
+          new_regions.append(result)
+      except StopIteration:
+        if not result:
+          # if there is no result, keep the current region
+          result = region
+        new_regions.append(result)
 
     # replace the selections with the new regions
     view.sel().clear()


### PR DESCRIPTION
BracketHighlighter recently added a way to extract the bracket locations from the view. Therefore we can use that information to make the expansion way smarter with very little work.

This PR extracts the BH brackets and our expansions. They are joined to get the "better"/closer one.

Example (`#ifdef` is defined by BracketHighligher):
![bh_example](https://cloud.githubusercontent.com/assets/12573621/22105518/bb8e30c0-de44-11e6-8e89-fa878536eef3.gif)

